### PR TITLE
Add helm args flexibility

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,6 +21,10 @@ on:
       chart_namespace:
         required: true
         type: string
+      helm_ext_args:
+        required: false
+        type: string
+        default: ''
 
     secrets:
       API_TOKEN_GITHUB:
@@ -86,7 +90,8 @@ jobs:
             --values=./chart/values/${{ inputs.env }}.yaml \
             ${region_values} \
             --set-string imageName=${{ inputs.registry }} \
-            --set-string imageTag=${{ inputs.tag }}
+            --set-string imageTag=${{ inputs.tag }} \
+            ${{ inputs.helm_ext_args }}
   
   # Deploy against all the regions specified in strategy.matrix.region
   deploy_all_regions:
@@ -133,4 +138,5 @@ jobs:
             --values=./chart/values/${{ inputs.env }}.yaml \
             ${region_values} \
             --set-string imageName=${{ inputs.registry }} \
-            --set-string imageTag=${{ inputs.tag }}
+            --set-string imageTag=${{ inputs.tag }} \
+            ${{ inputs.helm_ext_args }


### PR DESCRIPTION
This will add the deploy workflow the flexibility of allowing non-defined parameters like:
```yaml
    helm_ext_args: '--set-string field1=value1 --values=./chart/values/common.yaml'
```