### PR TITLE
Fix deployment, missing } bracket

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -139,4 +139,5 @@ jobs:
             ${region_values} \
             --set-string imageName=${{ inputs.registry }} \
             --set-string imageTag=${{ inputs.tag }} \
-            ${{ inputs.helm_ext_args }
+            ${{ inputs.helm_ext_args }}
+


### PR DESCRIPTION
    /.github/workflows/deploy.yaml@main (Line: 129, Col: 12):
    The expression is not closed.
    An unescaped ${{ sequence was found, but the closing }} sequence was not found.