### PR TITLE
Add linter for workflow files

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,28 +6,36 @@ on:
         required: false
         type: string
         default: 'us-east-1'
+        description: 'AWS region'
       tags:
         required: true
         type: string
+        description: 'Docker build tags'
       registry:
         required: true
         type: string
+        description: 'Registry image name'
       dockerfile_path:
         required: false
         type: string
         default: build/Dockerfile
+        description: 'Dockerfile relative path'
       docker_target:
         required: false
         type: string
         default: ''
-    
+        description: 'Dockerfile target'
+
     secrets:
       API_TOKEN_GITHUB:
         required: true
+        description: 'Github token hash'
       AWS_ACCESS_KEY_ID:
         required: true
+        description: 'AWS access key id'
       AWS_SECRET_ACCESS_KEY:
         required: true
+        description: 'AWS secret access key'
 
 jobs:
   release:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,48 +5,65 @@ on:
       env:
         required: true
         type: string
+        description: 'Kubernetes cluster environment'
       region:
         required: false
         type: string
         default: 'us-east-1'
+        description: 'AWS region'
       tag:
         required: true
         type: string
+        description: 'Image tag (semVer)'
       registry:
         required: true
         type: string
+        description: 'Image registry name'
       chart_name:
         required: true
         type: string
+        description: 'Helm chart name'
       chart_namespace:
         required: true
         type: string
+        description: 'Helm chart namespace'
       helm_ext_args:
         required: false
         type: string
         default: ''
+        description: 'Extra arguments for helm-update command'
 
     secrets:
       API_TOKEN_GITHUB:
         required: true
+        description: 'Github token hash'
       ORG_AWS_ACCESS_KEY_ID:
         required: true
+        description: 'AWS access key id'
       ORG_AWS_SECRET_ACCESS_KEY:
         required: true
+        description: 'AWS secret access key id'
       ORG_KUBECONFIG_DEV:
         required: true
+        description: 'Kubeconfig secret'
       ORG_KUBECONFIG_DEV_EU_WEST_1:
         required: false
+        description: 'Kubeconfig secret'
       ORG_KUBECONFIG_DEV_US_WEST_2:
         required: false
+        description: 'Kubeconfig secret'
       ORG_KUBECONFIG_PROD:
         required: true
+        description: 'Kubeconfig secret'
       ORG_KUBECONFIG_PROD_EU_WEST_1:
         required: false
+        description: 'Kubeconfig secret'
       ORG_KUBECONFIG_PROD_US_WEST_2:
         required: false
+        description: 'Kubeconfig secret'
       ORG_KUBECONFIG_STAGE:
         required: true
+        description: 'Kubeconfig secret'
 
 jobs:
   # Deploy by one region

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -16,9 +16,10 @@ jobs:
     - name: Get modified files
       id: files
       uses: jitterbit/get-changed-files@v1
+      continue-on-error: true
 
     - name: Download action linter
       run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
 
     - name: Run action linter
-      run: ./actionlint -oneline ${{ steps.files.outputs.all }}
+      run: ./actionlint -oneline -ignore 'label ".+" is unknown' -ignore '".+" is potentially untrusted' ${{ steps.files.outputs.all }} 

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -1,0 +1,24 @@
+name: Workflow linter
+on:
+  push:
+    paths:
+      - '.github/workflows/*'
+
+jobs:
+  workflow-linter:
+    runs-on: ubuntu-latest
+    name: Workflow linter
+    steps:
+
+    - name: Setup | Checkout submodules
+      uses: actions/checkout@v2
+
+    - name: Get modified files
+      id: files
+      uses: jitterbit/get-changed-files@v1
+
+    - name: Download action linter
+      run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+
+    - name: Run action linter
+      run: ./actionlint -oneline ${{ steps.files.outputs.all }}


### PR DESCRIPTION
For the sake of avoiding issues like the one reported in timescale/cloud-actions/pull/4 this workflow linter will error out upon a typo, i.e., if we miss a `}`:

```bash
$ actionlint -oneline -ignore 'label ".+" is unknown' -ignore '".+" is potentially untrusted'
deploy.yaml:99:594: got unexpected character '\n' while lexing end marker }}, expecting '}' [expression]
```