### PR TITLE
Enforce sequentail helm deploys

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -122,6 +122,7 @@ jobs:
   deploy_all_regions:
     if: inputs.region == 'all'
     strategy:
+      max-parallel: 1
       matrix:
         region: [us-east-1, us-west-2, eu-west-1, eu-central-1]
     runs-on: ${{ inputs.env }}-${{ matrix.region }}


### PR DESCRIPTION
While deploying the Deployer recently, 1 of the regions had a failure,
which caused the other 3 regions to abort their current GitHub Action
Job.

The problem however is that all those regions now had their DESCRIPTION
for this deployment set to 'Preparing upgrade', which caused subsequent
deployments to *always* fail.

Perhaps we can add a cleanup step to our jobs, until then, I think we
should enfore sequential deployments instead of parallel ones.