### PR TITLE
Make deploy action set region value via Helm flag

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -124,8 +124,9 @@ jobs:
             ${region_values} \
             --set-string imageName=${{ inputs.registry }} \
             --set-string imageTag=${{ inputs.tag }} \
+            --set-string deployment.region=${{ inputs.region }} \
             ${{ inputs.helm_ext_args }}
-  
+
   # Deploy against all the regions specified in strategy.matrix.region
   deploy_all_regions:
     if: inputs.region == 'all'
@@ -177,5 +178,5 @@ jobs:
             ${region_values} \
             --set-string imageName=${{ inputs.registry }} \
             --set-string imageTag=${{ inputs.tag }} \
+            --set-string deployment.region=${{ matrix.region }} \
             ${{ inputs.helm_ext_args }}
-


### PR DESCRIPTION
Several services that are deployed in multiple regions have to create
individual region values files just to set the region. When a new
region is added to the cluster, this means all of them need to be
updated instead of "just work." This change will now attempt to
override a `deployment.region` value with the region value from
the Action. This should be safe for those who don't use the value
since it will be ignored.

This was originally tried on a per-repo basis in Exporter using the
helm_ext_args var; however, the deploy 'all' regions directive did
not work because ${{ inputs.region }} was set to "all" and the
${{ matrix.region }} was not available at that level.