### PR TITLE
Upgrade to actions checkout v3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,57 +5,57 @@ on:
       region:
         required: false
         type: string
-        default: 'us-east-1'
-        description: 'AWS region'
+        default: "us-east-1"
+        description: "AWS region"
       tags:
         required: true
         type: string
-        description: 'Docker build tags'
+        description: "Docker build tags"
       registry:
         required: true
         type: string
-        description: 'Registry image name'
+        description: "Registry image name"
       dockerfile_path:
         required: false
         type: string
         default: build/Dockerfile
-        description: 'Dockerfile relative path'
+        description: "Dockerfile relative path"
       docker_target:
         required: false
         type: string
-        default: ''
-        description: 'Dockerfile target'
+        default: ""
+        description: "Dockerfile target"
 
     secrets:
       API_TOKEN_GITHUB:
         required: true
-        description: 'Github token hash'
+        description: "Github token hash"
       AWS_ACCESS_KEY_ID:
         required: true
-        description: 'AWS access key id'
+        description: "AWS access key id"
       AWS_SECRET_ACCESS_KEY:
         required: true
-        description: 'AWS secret access key'
+        description: "AWS secret access key"
 
 jobs:
   release:
     name: Build Docker
     runs-on: non-prod
     steps:
-    - name: Setup | Checkout
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-        token: ${{ secrets.API_TOKEN_GITHUB }}
+      - name: Setup | Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          token: ${{ secrets.API_TOKEN_GITHUB }}
 
-    - name: Docker | Build and Push
-      uses: timescale/cloud-actions/build-push@main
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        region: ${{ inputs.region }}
-        tags: |
-          ${{ inputs.tags }}
-        registry: ${{ inputs.registry }}
-        target: ${{ inputs.docker_target }}
-        file: ${{ inputs.dockerfile_path }}
+      - name: Docker | Build and Push
+        uses: timescale/cloud-actions/build-push@main
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          region: ${{ inputs.region }}
+          tags: |
+            ${{ inputs.tags }}
+          registry: ${{ inputs.registry }}
+          target: ${{ inputs.docker_target }}
+          file: ${{ inputs.dockerfile_path }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,77 +5,77 @@ on:
       env:
         required: true
         type: string
-        description: 'Kubernetes cluster environment'
+        description: "Kubernetes cluster environment"
       region:
         required: false
         type: string
-        default: 'us-east-1'
-        description: 'AWS region'
+        default: "us-east-1"
+        description: "AWS region"
       tag:
         required: true
         type: string
-        description: 'Image tag (semVer)'
+        description: "Image tag (semVer)"
       registry:
         required: true
         type: string
-        description: 'Image registry name'
+        description: "Image registry name"
       chart_name:
         required: true
         type: string
-        description: 'Helm chart name'
+        description: "Helm chart name"
       chart_namespace:
         required: true
         type: string
-        description: 'Helm chart namespace'
+        description: "Helm chart namespace"
       helm_ext_args:
         required: false
         type: string
-        default: ''
-        description: 'Extra arguments for helm-update command'
+        default: ""
+        description: "Extra arguments for helm-update command"
 
     secrets:
       API_TOKEN_GITHUB:
         required: true
-        description: 'Github token hash'
+        description: "Github token hash"
       ORG_AWS_ACCESS_KEY_ID:
         required: true
-        description: 'AWS access key id'
+        description: "AWS access key id"
       ORG_AWS_SECRET_ACCESS_KEY:
         required: true
-        description: 'AWS secret access key id'
+        description: "AWS secret access key id"
       ORG_KUBECONFIG_DEV:
         required: true
-        description: 'Kubeconfig secret'
+        description: "Kubeconfig secret"
       ORG_KUBECONFIG_DEV_EU_WEST_1:
         required: false
-        description: 'Kubeconfig secret'
+        description: "Kubeconfig secret"
       ORG_KUBECONFIG_DEV_US_WEST_2:
         required: false
-        description: 'Kubeconfig secret'
+        description: "Kubeconfig secret"
       ORG_KUBECONFIG_DEV_AP_SOUTHEAST_2:
         required: false
-        description: 'Kubeconfig secret'
+        description: "Kubeconfig secret"
       ORG_KUBECONFIG_PROD:
         required: true
-        description: 'Kubeconfig secret'
+        description: "Kubeconfig secret"
       ORG_KUBECONFIG_PROD_EU_WEST_1:
         required: false
-        description: 'Kubeconfig secret'
+        description: "Kubeconfig secret"
       ORG_KUBECONFIG_PROD_US_WEST_2:
         required: false
-        description: 'Kubeconfig secret'
+        description: "Kubeconfig secret"
       ORG_KUBECONFIG_PROD_EU_CENTRAL_1:
         required: false
-        description: 'Kubeconfig secret'
+        description: "Kubeconfig secret"
       ORG_KUBECONFIG_DEV_EU_CENTRAL_1:
         required: false
-        description: 'Kubeconfig secret'
+        description: "Kubeconfig secret"
       ORG_KUBECONFIG_STAGE:
         required: true
-        description: 'Kubeconfig secret'
+        description: "Kubeconfig secret"
       ORG_KUBECONFIG_PROD_AP_SOUTHEAST_2:
         required: false
-        description: 'Kubeconfig secret'
+        description: "Kubeconfig secret"
 
 jobs:
   # Deploy by one region
@@ -84,35 +84,34 @@ jobs:
     runs-on: ${{ inputs.env }}-${{ inputs.region }}
     name: Deploy ${{ inputs.env }}-${{ inputs.region }}@${{ inputs.tag }}
     steps:
+      - name: Setup | Checkout submodules
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          token: ${{ secrets.API_TOKEN_GITHUB }}
 
-    - name: Setup | Checkout submodules
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-        token: ${{ secrets.API_TOKEN_GITHUB }}
+      - name: ECR and k8s login
+        uses: timescale/cloud-actions/ecr-k8s-login@main
+        env:
+          ORG_KUBECONFIG_DEV: ${{ secrets.ORG_KUBECONFIG_DEV }}
+          ORG_KUBECONFIG_DEV_EU_WEST_1: ${{ secrets.ORG_KUBECONFIG_DEV_EU_WEST_1 }}
+          ORG_KUBECONFIG_DEV_US_WEST_2: ${{ secrets.ORG_KUBECONFIG_DEV_US_WEST_2 }}
+          ORG_KUBECONFIG_PROD: ${{ secrets.ORG_KUBECONFIG_PROD }}
+          ORG_KUBECONFIG_PROD_EU_WEST_1: ${{ secrets.ORG_KUBECONFIG_PROD_EU_WEST_1 }}
+          ORG_KUBECONFIG_PROD_US_WEST_2: ${{ secrets.ORG_KUBECONFIG_PROD_US_WEST_2 }}
+          ORG_KUBECONFIG_STAGE: ${{ secrets.ORG_KUBECONFIG_STAGE }}
+          ORG_KUBECONFIG_DEV_EU_CENTRAL_1: ${{ secrets.ORG_KUBECONFIG_DEV_EU_CENTRAL_1 }}
+          ORG_KUBECONFIG_PROD_EU_CENTRAL_1: ${{ secrets.ORG_KUBECONFIG_PROD_EU_CENTRAL_1 }}
+          ORG_KUBECONFIG_DEV_AP_SOUTHEAST_2: ${{ secrets.ORG_KUBECONFIG_DEV_AP_SOUTHEAST_2 }}
+          ORG_KUBECONFIG_PROD_AP_SOUTHEAST_2: ${{ secrets.ORG_KUBECONFIG_PROD_AP_SOUTHEAST_2 }}
+        with:
+          aws-access-key-id: ${{ secrets.ORG_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ORG_AWS_SECRET_ACCESS_KEY }}
+          regions: ${{ inputs.region }}
+          env: ${{ inputs.env }}
 
-    - name: ECR and k8s login
-      uses: timescale/cloud-actions/ecr-k8s-login@main
-      env:
-        ORG_KUBECONFIG_DEV: ${{ secrets.ORG_KUBECONFIG_DEV }}
-        ORG_KUBECONFIG_DEV_EU_WEST_1: ${{ secrets.ORG_KUBECONFIG_DEV_EU_WEST_1 }}
-        ORG_KUBECONFIG_DEV_US_WEST_2: ${{ secrets.ORG_KUBECONFIG_DEV_US_WEST_2 }}
-        ORG_KUBECONFIG_PROD: ${{ secrets.ORG_KUBECONFIG_PROD }}
-        ORG_KUBECONFIG_PROD_EU_WEST_1: ${{ secrets.ORG_KUBECONFIG_PROD_EU_WEST_1 }}
-        ORG_KUBECONFIG_PROD_US_WEST_2: ${{ secrets.ORG_KUBECONFIG_PROD_US_WEST_2 }}
-        ORG_KUBECONFIG_STAGE: ${{ secrets.ORG_KUBECONFIG_STAGE }}
-        ORG_KUBECONFIG_DEV_EU_CENTRAL_1: ${{ secrets.ORG_KUBECONFIG_DEV_EU_CENTRAL_1 }}
-        ORG_KUBECONFIG_PROD_EU_CENTRAL_1: ${{ secrets.ORG_KUBECONFIG_PROD_EU_CENTRAL_1 }}
-        ORG_KUBECONFIG_DEV_AP_SOUTHEAST_2: ${{ secrets.ORG_KUBECONFIG_DEV_AP_SOUTHEAST_2 }}
-        ORG_KUBECONFIG_PROD_AP_SOUTHEAST_2: ${{ secrets.ORG_KUBECONFIG_PROD_AP_SOUTHEAST_2 }}
-      with:
-        aws-access-key-id: ${{ secrets.ORG_AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.ORG_AWS_SECRET_ACCESS_KEY }}
-        regions: ${{ inputs.region }}
-        env:  ${{ inputs.env }}
-
-    - name: Helm Upgrade
-      run: |
+      - name: Helm Upgrade
+        run: |
           region_values=''
           if [[ -e "./chart/values/${{ inputs.env }}-${{ inputs.region }}.yaml" ]]; then
             region_values=--values=./chart/values/${{ inputs.env }}-${{ inputs.region }}.yaml
@@ -137,35 +136,34 @@ jobs:
     runs-on: ${{ inputs.env }}-${{ matrix.region }}
     name: Deploy-all  ${{ inputs.env }}-${{ matrix.region }}@${{ inputs.tag }}
     steps:
+      - name: Setup | Checkout submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+          token: ${{ secrets.API_TOKEN_GITHUB }}
 
-    - name: Setup | Checkout submodules
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-        token: ${{ secrets.API_TOKEN_GITHUB }}
+      - name: ECR and k8s login
+        uses: timescale/cloud-actions/ecr-k8s-login@main
+        env:
+          ORG_KUBECONFIG_DEV: ${{ secrets.ORG_KUBECONFIG_DEV }}
+          ORG_KUBECONFIG_DEV_EU_WEST_1: ${{ secrets.ORG_KUBECONFIG_DEV_EU_WEST_1 }}
+          ORG_KUBECONFIG_DEV_US_WEST_2: ${{ secrets.ORG_KUBECONFIG_DEV_US_WEST_2 }}
+          ORG_KUBECONFIG_PROD: ${{ secrets.ORG_KUBECONFIG_PROD }}
+          ORG_KUBECONFIG_PROD_EU_WEST_1: ${{ secrets.ORG_KUBECONFIG_PROD_EU_WEST_1 }}
+          ORG_KUBECONFIG_PROD_US_WEST_2: ${{ secrets.ORG_KUBECONFIG_PROD_US_WEST_2 }}
+          ORG_KUBECONFIG_STAGE: ${{ secrets.ORG_KUBECONFIG_STAGE }}
+          ORG_KUBECONFIG_DEV_EU_CENTRAL_1: ${{ secrets.ORG_KUBECONFIG_DEV_EU_CENTRAL_1 }}
+          ORG_KUBECONFIG_PROD_EU_CENTRAL_1: ${{ secrets.ORG_KUBECONFIG_PROD_EU_CENTRAL_1 }}
+          ORG_KUBECONFIG_DEV_AP_SOUTHEAST_2: ${{ secrets.ORG_KUBECONFIG_DEV_AP_SOUTHEAST_2 }}
+          ORG_KUBECONFIG_PROD_AP_SOUTHEAST_2: ${{ secrets.ORG_KUBECONFIG_PROD_AP_SOUTHEAST_2 }}
+        with:
+          aws-access-key-id: ${{ secrets.ORG_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ORG_AWS_SECRET_ACCESS_KEY }}
+          regions: ${{ matrix.region }}
+          env: ${{ inputs.env }}
 
-    - name: ECR and k8s login
-      uses: timescale/cloud-actions/ecr-k8s-login@main
-      env:
-        ORG_KUBECONFIG_DEV: ${{ secrets.ORG_KUBECONFIG_DEV }}
-        ORG_KUBECONFIG_DEV_EU_WEST_1: ${{ secrets.ORG_KUBECONFIG_DEV_EU_WEST_1 }}
-        ORG_KUBECONFIG_DEV_US_WEST_2: ${{ secrets.ORG_KUBECONFIG_DEV_US_WEST_2 }}
-        ORG_KUBECONFIG_PROD: ${{ secrets.ORG_KUBECONFIG_PROD }}
-        ORG_KUBECONFIG_PROD_EU_WEST_1: ${{ secrets.ORG_KUBECONFIG_PROD_EU_WEST_1 }}
-        ORG_KUBECONFIG_PROD_US_WEST_2: ${{ secrets.ORG_KUBECONFIG_PROD_US_WEST_2 }}
-        ORG_KUBECONFIG_STAGE: ${{ secrets.ORG_KUBECONFIG_STAGE }}
-        ORG_KUBECONFIG_DEV_EU_CENTRAL_1: ${{ secrets.ORG_KUBECONFIG_DEV_EU_CENTRAL_1 }}
-        ORG_KUBECONFIG_PROD_EU_CENTRAL_1: ${{ secrets.ORG_KUBECONFIG_PROD_EU_CENTRAL_1 }}
-        ORG_KUBECONFIG_DEV_AP_SOUTHEAST_2: ${{ secrets.ORG_KUBECONFIG_DEV_AP_SOUTHEAST_2 }}
-        ORG_KUBECONFIG_PROD_AP_SOUTHEAST_2: ${{ secrets.ORG_KUBECONFIG_PROD_AP_SOUTHEAST_2 }}
-      with:
-        aws-access-key-id: ${{ secrets.ORG_AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.ORG_AWS_SECRET_ACCESS_KEY }}
-        regions: ${{ matrix.region }}
-        env:  ${{ inputs.env }}
-
-    - name: Helm Upgrade
-      run: |
+      - name: Helm Upgrade
+        run: |
           echo "####### Helm upgrade for ${{ inputs.env }}_${{ matrix.region }} ####### "
           region_values=''
           if [[ -e "./chart/values/${{ inputs.env }}-${{ matrix.region }}.yaml" ]]; then

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -2,24 +2,23 @@ name: Workflow linter
 on:
   push:
     paths:
-      - '.github/workflows/*'
+      - ".github/workflows/*"
 
 jobs:
   workflow-linter:
     runs-on: ubuntu-latest
     name: Workflow linter
     steps:
+      - name: Setup | Checkout submodules
+        uses: actions/checkout@v3
 
-    - name: Setup | Checkout submodules
-      uses: actions/checkout@v2
+      - name: Get modified files
+        id: files
+        uses: jitterbit/get-changed-files@v1
+        continue-on-error: true
 
-    - name: Get modified files
-      id: files
-      uses: jitterbit/get-changed-files@v1
-      continue-on-error: true
+      - name: Download action linter
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
 
-    - name: Download action linter
-      run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-
-    - name: Run action linter
-      run: ./actionlint -oneline -ignore 'label ".+" is unknown' -ignore '".+" is potentially untrusted' ${{ steps.files.outputs.all }} 
+      - name: Run action linter
+        run: ./actionlint -oneline -ignore 'label ".+" is unknown' -ignore '".+" is potentially untrusted' ${{ steps.files.outputs.all }}


### PR DESCRIPTION
This PR fixes the warning: 
`
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout
`