### PR TITLE
Upgrade to actions/checkout@v3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
     runs-on: non-prod
     steps:
     - name: Setup | Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
         token: ${{ secrets.API_TOKEN_GITHUB }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -86,7 +86,7 @@ jobs:
     steps:
 
     - name: Setup | Checkout submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
         token: ${{ secrets.API_TOKEN_GITHUB }}

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
     - name: Setup | Checkout submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get modified files
       id: files


### PR DESCRIPTION
This PR fixes the warning:
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout