### PR TITLE
Increase helm's timeout to 10m

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -135,6 +135,7 @@ jobs:
             --kubeconfig=./kubeconfig_${{ inputs.env }}_${{ inputs.region }} \
             --namespace=${{ inputs.chart_namespace }} \
             --values=./${{ inputs.chart_path }}/values/${{ inputs.env }}.yaml \
+            --timeout 10m \
             ${region_values} \
             ${standard_values} \
             ${{ inputs.helm_ext_args }}
@@ -191,6 +192,7 @@ jobs:
             --kubeconfig=./kubeconfig_${{ inputs.env }}_${{ matrix.region }} \
             --namespace=${{ inputs.chart_namespace }} \
             --values=./${{ inputs.chart_path }}/values/${{ inputs.env }}.yaml \
+            --timeout 10m \
             ${region_values} \
             ${standard_values} \
             ${{ inputs.helm_ext_args }}


### PR DESCRIPTION
5m isn't long enough if the deployment triggers an autoscale

This is what I was seeing for a dev deployment of the deployer:
```
Events:
  Type     Reason                  Age                    From                Message
  ----     ------                  ----                   ----                -------
  Normal   Scheduled               74s                    default-scheduler   Successfully assigned savannah-system/deployer-service-7d5c97d55d-cv68j to ip-172-20-55-158.ec2.internal
  Warning  FailedScheduling        5m2s (x1 over 5m5s)    default-scheduler   0/75 nodes are available: 10 Insufficient cpu, 10 node(s) had taint {savannah/role: proxy}, that the pod didn't tolerate, 3 Insufficient memory, 36 node(s) had taint {savannah/role: users-paid}, that the pod didn't tolerate, 4 node(s) had taint {savannah/role: users-paid-default}, that the pod didn't tolerate, 4 node(s) were unschedulable, 5 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate, 6 node(s) had taint {savannah/role: cicd}, that the pod didn't tolerate.
  Warning  FailedScheduling        4m42s (x1 over 4m51s)  default-scheduler   0/76 nodes are available: 1 Too many pods, 10 node(s) had taint {savannah/role: proxy}, that the pod didn't tolerate, 11 Insufficient cpu, 36 node(s) had taint {savannah/role: users-paid}, that the pod didn't tolerate, 4 Insufficient memory, 4 node(s) had taint {savannah/role: users-paid-default}, that the pod didn't tolerate, 4 node(s) were unschedulable, 5 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate, 6 node(s) had taint {savannah/role: cicd}, that the pod didn't tolerate.
  Warning  FailedScheduling        110s (x1 over 2m47s)   default-scheduler   0/76 nodes are available: 1 node(s) had taint {node.kubernetes.io/unreachable: }, that the pod didn't tolerate, 10 Insufficient cpu, 10 node(s) had taint {savannah/role: proxy}, that the pod didn't tolerate, 3 Insufficient memory, 36 node(s) had taint {savannah/role: users-paid}, that the pod didn't tolerate, 4 node(s) had taint {savannah/role: users-paid-default}, that the pod didn't tolerate, 4 node(s) were unschedulable, 5 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate, 6 node(s) had taint {savannah/role: cicd}, that the pod didn't tolerate.
  Warning  FailedScheduling        5m6s                   default-scheduler   0/75 nodes are available: 10 Insufficient cpu, 10 node(s) had taint {savannah/role: proxy}, that the pod didn't tolerate, 3 Insufficient memory, 36 node(s) had taint {savannah/role: users-paid}, that the pod didn't tolerate, 4 node(s) had taint {savannah/role: users-paid-default}, that the pod didn't tolerate, 4 node(s) were unschedulable, 5 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate, 6 node(s) had taint {savannah/role: cicd}, that the pod didn't tolerate.
  Warning  FailedScheduling        84s                    default-scheduler   0/77 nodes are available: 1 Too many pods, 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate, 10 node(s) had taint {savannah/role: proxy}, that the pod didn't tolerate, 11 Insufficient cpu, 36 node(s) had taint {savannah/role: users-paid}, that the pod didn't tolerate, 4 Insufficient memory, 4 node(s) had taint {savannah/role: users-paid-default}, that the pod didn't tolerate, 4 node(s) were unschedulable, 5 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate, 6 node(s) had taint {savannah/role: cicd}, that the pod didn't tolerate.
  Normal   NotTriggerScaleUp       4m58s                  cluster-autoscaler  pod didn't trigger scale-up: 40 node(s) had taint {savannah/role: users-paid}, that the pod didn't tolerate, 5 node(s) had taint {savannah/role: proxy}, that the pod didn't tolerate, 5 node(s) had taint {savannah/role: users-paid-default}, that the pod didn't tolerate
  Normal   Nominate                2m59s (x3 over 5m2s)   karpenter           Pod should schedule on ip-172-20-55-158.ec2.internal
  Normal   Nominate                103s (x2 over 105s)    karpenter           Pod should schedule on ip-172-20-46-172.ec2.internal
  Warning  FailedCreatePodSandBox  73s                    kubelet             Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "8b1a817f396a9f3ef1cd9170e725c7f3e0d11ce6ee79c69ab4f1ce8bb48e3a75": stat /var/lib/calico/nodename: no such file or directory: check that the calico/node container is running and has mounted /var/lib/calico/
  Warning  FailedCreatePodSandBox  59s                    kubelet             Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "54bed22d8d9aac609b04cccdbe6e652af982612971c3741375809ffe93aaea41": stat /var/lib/calico/nodename: no such file or directory: check that the calico/node container is running and has mounted /var/lib/calico/
  Warning  FailedCreatePodSandBox  45s                    kubelet             Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "c973b7ae891eb5718d3c4f4aadf5da1fe5d4f8c15a42884c4c766f3d50303110": stat /var/lib/calico/nodename: no such file or directory: check that the calico/node container is running and has mounted /var/lib/calico/
  Normal   Pulling                 32s                    kubelet             Pulling image "cr.l5d.io/linkerd/proxy-init:v1.4.0"
  Normal   Created                 20s                    kubelet             Created container linkerd-init
  Normal   Pulled                  20s                    kubelet             Successfully pulled image "cr.l5d.io/linkerd/proxy-init:v1.4.0" in 11.390643541s
  Normal   Started                 20s                    kubelet             Started container linkerd-init
  Normal   Pulling                 19s                    kubelet             Pulling image "cr.l5d.io/linkerd/proxy:stable-2.11.1"
  Normal   Pulling                 15s                    kubelet             Pulling image "142548018081.dkr.ecr.us-east-1.amazonaws.com/savannah-deployer:v0.60.2"
  Normal   Created                 15s                    kubelet             Created container linkerd-proxy
  Normal   Started                 15s                    kubelet             Started container linkerd-proxy
  Normal   Pulled                  15s                    kubelet             Successfully pulled image "cr.l5d.io/linkerd/proxy:stable-2.11.1" in 4.211184185s
  Normal   Pulled                  9s                     kubelet             Successfully pulled image "142548018081.dkr.ecr.us-east-1.amazonaws.com/savannah-deployer:v0.60.2" in 5.327057938s
  Normal   Created                 8s                     kubelet             Created container deployer-service
  Normal   Started                 8s                     kubelet             Started container deployer-service
  Normal   Killing                 5s                     kubelet             Stopping container linkerd-proxy
  Normal   Killing                 5s                     kubelet             Stopping container deployer-service
```