### PR TITLE
Include helm timeout new param

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,6 +42,11 @@ on:
         type: string
         default: 'true'
         description: 'Inject the standard imageName, imageTag, and deployment.region values via --set-string'
+      helm_timeout:
+        required: false
+        type: string
+        default: '5m'
+        description: 'Extra arguments to specify timeout for help upgrades'
 
     secrets:
       API_TOKEN_GITHUB:
@@ -132,7 +137,7 @@ jobs:
             --kubeconfig=./kubeconfig_${{ inputs.env }}_${{ inputs.region }} \
             --namespace=${{ inputs.chart_namespace }} \
             --values=./${{ inputs.chart_path }}/values/${{ inputs.env }}.yaml \
-            --timeout 10m \
+            --timeout ${{ inputs.helm_timeout }} \
             ${region_values} \
             ${standard_values} \
             ${{ inputs.helm_ext_args }}
@@ -183,7 +188,7 @@ jobs:
             --kubeconfig=./kubeconfig_${{ inputs.env }}_${{ matrix.region }} \
             --namespace=${{ inputs.chart_namespace }} \
             --values=./${{ inputs.chart_path }}/values/${{ inputs.env }}.yaml \
-            --timeout 10m \
+            --timeout ${{ inputs.helm_timeout }} \
             ${region_values} \
             ${standard_values} \
             ${{ inputs.helm_ext_args }}
@@ -232,7 +237,7 @@ jobs:
             --kubeconfig=./kubeconfig_${{ inputs.env }}_${{ matrix.region }} \
             --namespace=${{ inputs.chart_namespace }} \
             --values=./${{ inputs.chart_path }}/values/${{ inputs.env }}.yaml \
-            --timeout 10m \
+            --timeout ${{ inputs.helm_timeout }} \
             ${region_values} \
             ${standard_values} \
             ${{ inputs.helm_ext_args }}

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -22,4 +22,9 @@ jobs:
       run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
 
     - name: Run action linter
-      run: ./actionlint -oneline -ignore 'label ".+" is unknown' -ignore '".+" is potentially untrusted' ${{ steps.files.outputs.all }} 
+      run: |
+        ./actionlint -oneline -ignore 'label ".+" is unknown' \
+          -ignore '".+" is potentially untrusted' \
+          -ignore '".+" SC2086 ".+"' \
+          ${{ steps.files.outputs.all }} \
+          


### PR DESCRIPTION
Timeout for helm upgrades was raised due to slow deployments in savannah-deployer, [PR](https://github.com/timescale/cloud-actions/pull/16).
With this change, we allow the users of the Action to increase it up to their needs, so we can still rely on a timeout of 5m (helm default) for most of the use cases.

Also adding another lint rule to ignore errors related to shellcheck in helm commands.