### PR TITLE
Replace / with - in tag names

### DIFF
--- a/build-push/build-push.sh
+++ b/build-push/build-push.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 for tag in ${tags}; do
+    # Search-and-replace all / characters to -, which allows using github.ref_name in the tag since most branches include a / character.
+    tag="${tag//\//-}"
+
     # If there is a target we use it
     echo "Building ${registry}:${tag}"
     [[ ${target} = '' ]] && docker build -t ${registry}:${tag} -f ${dockerfile} . || docker build -t ${registry}:${tag} --target ${target} -f ${dockerfile} .


### PR DESCRIPTION
This allows using github.ref_name in tags, since most of the time our branch names include slashes in them.