### PR TITLE
Avoid name colision when uploading artifact

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -135,7 +135,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ env.PLATFORM_PAIR }}
+          name: digests-${{ env.PLATFORM_DASH_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1


### PR DESCRIPTION
We're seeing the following error when building multi-platform images during upload artifact step:

`Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run `

This should be fixed by using the correct platform pair var names.
