### PR TITLE
add ap-south-1 (Mumbai) to deploy.yaml

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -109,6 +109,9 @@ on:
       ORG_KUBECONFIG_PROD_SA_EAST_1:
         required: false
         description: 'Kubeconfig secret'
+      ORG_KUBECONFIG_PROD_AP_SOUTH_1:
+        required: false
+        description: 'Kubeconfig secret'
 jobs:
   # Deploy by one region
   deploy_on_region:
@@ -140,6 +143,7 @@ jobs:
         ORG_KUBECONFIG_PROD_EU_WEST_2: ${{ secrets.ORG_KUBECONFIG_PROD_EU_WEST_2 }}
         ORG_KUBECONFIG_PROD_CA_CENTRAL_1: ${{ secrets.ORG_KUBECONFIG_PROD_CA_CENTRAL_1 }}
         ORG_KUBECONFIG_PROD_SA_EAST_1: ${{ secrets.ORG_KUBECONFIG_PROD_SA_EAST_1 }}
+        ORG_KUBECONFIG_PROD_AP_SOUTH_1: ${{ secrets.ORG_KUBECONFIG_PROD_AP_SOUTH_1 }}
       with:
         aws-access-key-id: ${{ secrets.ORG_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.ORG_AWS_SECRET_ACCESS_KEY }}
@@ -196,6 +200,7 @@ jobs:
         ORG_KUBECONFIG_PROD_EU_WEST_2: ${{ secrets.ORG_KUBECONFIG_PROD_EU_WEST_2 }}
         ORG_KUBECONFIG_PROD_CA_CENTRAL_1: ${{ secrets.ORG_KUBECONFIG_PROD_CA_CENTRAL_1 }}
         ORG_KUBECONFIG_PROD_SA_EAST_1: ${{ secrets.ORG_KUBECONFIG_PROD_SA_EAST_1 }}
+        ORG_KUBECONFIG_PROD_AP_SOUTH_1: ${{ secrets.ORG_KUBECONFIG_PROD_AP_SOUTH_1 }}
       with:
         aws-access-key-id: ${{ secrets.ORG_AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.ORG_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Include _ORG_KUBECONFIG_PROD_AP_SOUTH_1_ secret, required for the new region ap-south-1 (Mumbai) according to [Multiregion doc, step 5. Get CICD working]( https://github.com/timescale/savannah-infra/blob/master/docs/multiregion.md) to deploy.yaml.