### PR TITLE
Allow specifying location of Dockerfile in mp builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -115,6 +115,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: ${{ inputs.dockerfile_path }}
           platforms: linux/${{ matrix.platform }}
           target: ${{ inputs.docker_target }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Add inputs.dockerfile_path.
This may break existing mutliplatform builds relying on the default, since they used ./Dockerfile