### PR TITLE
Sync the mp and non-mp checkouts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,6 +85,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.API_TOKEN_GITHUB }}
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
Submodules weren't being included in mp builds