### PR TITLE
Actions to scan code and images for vulnerabilities

### DIFF
--- a/scan-image/README.md
+++ b/scan-image/README.md
@@ -1,0 +1,19 @@
+## Description
+Scan image for vulnerabilities
+
+- How to use it:
+```yaml
+    - name: Scan image for vulnerabilities
+      uses: timescale/cloud-actions/scan-image@main
+      with:
+        region: us-east-1 #OPTIONAL (Default to us-east-1)
+        registry: "142548018081.dkr.ecr.us-east-1.amazonaws.com" #REQUIRED
+        image: <image-name>:<tag> #REQUIRED
+        report-format: table #OPTIONAL (Default to json)
+        severity: CRITICAL #OPTIONAL (Default to CRITICAL,HIGH)
+      secrets:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }} #REQUIRED
+        aws-secret-access-key: ${{ secrets._AWS_SECRET_ACCESS_KEY }} #REQUIRED
+```
+
+This action will always succeed, even if vulnerabilities are found. The report that can be used to track and remediate vulnerabilities will be uploaded as an artifact to the workflow run.

--- a/scan-image/action.yaml
+++ b/scan-image/action.yaml
@@ -1,0 +1,57 @@
+name: 'Scan Image'
+description: 'Scan an image for vulnerabilities'
+inputs:
+  aws-access-key-id:
+    description: 'AWS Key ID secret name'
+    required: true
+  aws-secret-access-key:
+    description: 'AWS Access Key secret name'
+    required: true
+  region:
+    description: 'AWS region'
+    required: false
+    default: 'us-east-1'
+  registry:
+    description: 'ECR image repository'
+    required: true
+  image:
+    description: 'ECR image name & tag'
+    required: true
+  report-format:
+    description: 'Report format (sarif, json, table)'
+    required: false
+    default: 'json'
+  severity:
+    description: 'Severity level (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)'
+    required: false
+    default: 'CRITICAL,HIGH'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: ${{ inputs.region }}
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@0.29.0
+      with:
+        scan-type: 'image'
+        image-ref: '${{ inputs.registry }}/${{ inputs.image }}'
+        output: trivy-image.report
+        format: ${{ inputs.report-format }}
+        severity: ${{ inputs.severity }}
+        exit-code: 0
+
+    - name: Upload Vulnerability Scan Results
+      uses: actions/upload-artifact@v4
+      with:
+        name: trivy-image
+        path: trivy-image.report
+        retention-days: 30

--- a/scan-repository/README.md
+++ b/scan-repository/README.md
@@ -1,0 +1,13 @@
+## Description
+Scan current repository for vulnerabilities
+
+- How to use it:
+```yaml
+    - name: Scan repository for vulnerabilities
+      uses: timescale/cloud-actions/scan-repository@main
+      with:
+        report-format: table #OPTIONAL (Default to json)
+        severity: CRITICAL #OPTIONAL (Default to CRITICAL,HIGH)
+```
+
+This action will fail if vulnerabilities are found. The report that can be used to track and remediate vulnerabilities will be uploaded as an artifact to the workflow run.

--- a/scan-repository/action.yaml
+++ b/scan-repository/action.yaml
@@ -1,0 +1,42 @@
+name: 'Scan Repository'
+description: 'Scan repository for vulnerabilities'
+inputs:
+  report-format:
+    description: 'Report format (sarif, json, table)'
+    required: false
+    default: 'json'
+  severity:
+    description: 'Severity level (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)'
+    required: false
+    default: 'CRITICAL,HIGH'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate Trivy Vulnerability Report
+      uses: aquasecurity/trivy-action@0.29.0
+      with:
+        scan-type: "fs"
+        output: trivy-repository.report
+        format: ${{ inputs.report-format }}
+        scan-ref: .
+        exit-code: 0
+
+    - name: Upload Vulnerability Scan Results
+      uses: actions/upload-artifact@v4
+      with:
+        name: trivy-repository
+        path: trivy-repository.report
+        retention-days: 30
+
+    - name: Fail build on Found Vulnerabilities
+      uses: aquasecurity/trivy-action@0.29.0
+      with:
+        scan-type: "fs"
+        format: table
+        scan-ref: .
+        severity: ${{ inputs.severity }}
+        ignore-unfixed: true
+        exit-code: 1
+        # On a subsequent call to the action we know trivy is already installed so can skip this
+        skip-setup-trivy: true


### PR DESCRIPTION
Two actions introduced in the PR:

- scan-image
- scan-repository

### scan-image action

This actions scans container image for vulnerabilities. After scan the report in chosen format (json by default) will be uploaded as an artifact to the workflow run.

[trivy-report-image.json](https://github.com/user-attachments/files/18895203/trivy-report-image.json)

### scan-repository action

This action scans filesystem for vulnerabilities. After scan the report in chosen format (json by default) will be uploaded as an artifact to the workflow run. This action will fail in case vulnerabilities of specified severity were found.

[trivy-report.json](https://github.com/user-attachments/files/18895224/trivy-report.json)
