### PR TITLE
add scan to build action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ on:
         description: 'Fail build on found vulnerabilities'
         type: boolean
         required: false
-        default: 'true'
+        default: 'false'
       ignore-unfixed:
         description: 'Ignore unfixed vulnerabilities'
         type: boolean

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,12 +44,12 @@ on:
         description: 'Fail build on found vulnerabilities'
         type: boolean
         required: false
-        default: 'false'
+        default: false
       ignore-unfixed:
         description: 'Ignore unfixed vulnerabilities'
         type: boolean
         required: false
-        default: 'true'
+        default: true
     secrets:
       API_TOKEN_GITHUB:
         required: true
@@ -94,8 +94,8 @@ jobs:
           tags: |
             ${{ inputs.tags }}
           severity: ${{ inputs.severity }}
-          ignore-unfixed: ${{ inputs.ignore-unfixed }}
-          fail-on-vulns: ${{ inputs.fail-on-vulns }}
+          ignore-unfixed: '${{ inputs.ignore-unfixed }}'
+          fail-on-vulns: '${{ inputs.fail-on-vulns }}'
 
   mp-build:
     name: Build multiplatform Image (${{ matrix.platform }})
@@ -165,8 +165,8 @@ jobs:
           registry: ${{ inputs.registry }}
           digest: "${{ steps.build.outputs.digest }}"
           severity: ${{ inputs.severity }}
-          ignore-unfixed: ${{ inputs.ignore-unfixed }}
-          fail-on-vulns: ${{ inputs.fail-on-vulns }}
+          ignore-unfixed: '${{ inputs.ignore-unfixed }}'
+          fail-on-vulns: '${{ inputs.fail-on-vulns }}'
 
       - name: Export digest
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
           file: ${{ inputs.dockerfile_path }}
 
       - name: Scan Image
-        uses: timescale/cloud-actions/scan-report@2fb1e775430c448a5a63fd03c2731341e26d85c1
+        uses: timescale/cloud-actions/scan-report@main
         with:
           report-name: 'image-scan'
           report-filename: 'image-scan.report'
@@ -157,7 +157,7 @@ jobs:
             BPF_TARGET=${{ matrix.platform }}
 
       - name: Scan Image
-        uses: timescale/cloud-actions/scan-report@2fb1e775430c448a5a63fd03c2731341e26d85c1
+        uses: timescale/cloud-actions/scan-report@main
         with:
           report-name: 'image-scan-${{ inputs.docker_target }}-${{ matrix.platform }}'
           report-filename: 'image-scan-${{ inputs.docker_target }}-${{ matrix.platform }}.report'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
           file: ${{ inputs.dockerfile_path }}
 
       - name: Scan Image
-        uses: timescale/cloud-actions/scan-report@9df8d162ba97e4a1f1556f736dd0163e98f7204d
+        uses: timescale/cloud-actions/scan-report@main
         with:
           report-name: 'image-scan'
           report-filename: 'image-scan.report'
@@ -157,7 +157,7 @@ jobs:
             BPF_TARGET=${{ matrix.platform }}
 
       - name: Scan Image
-        uses: timescale/cloud-actions/scan-report@9df8d162ba97e4a1f1556f736dd0163e98f7204d
+        uses: timescale/cloud-actions/scan-report@main
         with:
           report-name: 'image-scan-${{ inputs.target }}-${{ matrix.platform }}'
           report-filename: 'image-scan-${{ inputs.target }}-${{ matrix.platform }}.report'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
           file: ${{ inputs.dockerfile_path }}
 
       - name: Scan Image
-        uses: timescale/cloud-actions/scan-report@b47e350efec52fb2a31d7ad02f144c52eb571d3c
+        uses: timescale/cloud-actions/scan-report@61d7c6131a7f4659ecab0527e4188bdee25d9cbc
         with:
           report-name: 'image-scan'
           report-filename: 'image-scan.report'
@@ -157,7 +157,7 @@ jobs:
             BPF_TARGET=${{ matrix.platform }}
 
       - name: Scan Image
-        uses: timescale/cloud-actions/scan-report@b47e350efec52fb2a31d7ad02f144c52eb571d3c
+        uses: timescale/cloud-actions/scan-report@61d7c6131a7f4659ecab0527e4188bdee25d9cbc
         with:
           report-name: 'image-scan-${{ inputs.docker_target }}-${{ matrix.platform }}'
           report-filename: 'image-scan-${{ inputs.docker_target }}-${{ matrix.platform }}.report'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -159,14 +159,16 @@ jobs:
       - name: Scan Image
         uses: timescale/cloud-actions/scan-report@main
         with:
-          report-name: 'image-scan-${{ inputs.target }}-${{ matrix.platform }}'
-          report-filename: 'image-scan-${{ inputs.target }}-${{ matrix.platform }}.report'
-          identifier: '${{ inputs.registry }}-${{ inputs.target }}-${{ matrix.platform }}'
+          report-name: 'image-scan-${{ inputs.docker_target }}-${{ matrix.platform }}'
+          report-filename: 'image-scan-${{ inputs.docker_target }}-${{ matrix.platform }}.report'
+          identifier: '${{ inputs.registry }}-${{ inputs.docker_target }}-${{ matrix.platform }}'
           registry: ${{ inputs.registry }}
           digest: "${{ steps.build.outputs.digest }}"
           severity: ${{ inputs.severity }}
           ignore-unfixed: '${{ inputs.ignore-unfixed }}'
           fail-on-vulns: '${{ inputs.fail-on-vulns }}'
+        env:
+          TRIVY_PLATFORM: linux/${{ matrix.platform }}
 
       - name: Export digest
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
           file: ${{ inputs.dockerfile_path }}
 
       - name: Scan Image
-        uses: timescale/cloud-actions/scan-report@3dcd878456384510ab091a51d70cc1a500d76b1d
+        uses: timescale/cloud-actions/scan-report@b47e350efec52fb2a31d7ad02f144c52eb571d3c
         with:
           report-name: 'image-scan'
           report-filename: 'image-scan.report'
@@ -157,7 +157,7 @@ jobs:
             BPF_TARGET=${{ matrix.platform }}
 
       - name: Scan Image
-        uses: timescale/cloud-actions/scan-report@3dcd878456384510ab091a51d70cc1a500d76b1d
+        uses: timescale/cloud-actions/scan-report@b47e350efec52fb2a31d7ad02f144c52eb571d3c
         with:
           report-name: 'image-scan-${{ inputs.docker_target }}-${{ matrix.platform }}'
           report-filename: 'image-scan-${{ inputs.docker_target }}-${{ matrix.platform }}.report'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
           file: ${{ inputs.dockerfile_path }}
 
       - name: Scan Image
-        uses: timescale/cloud-actions/scan-report@61d7c6131a7f4659ecab0527e4188bdee25d9cbc
+        uses: timescale/cloud-actions/scan-report@74b7a34f9fb318e8a2faabb2169d0f0ba5ec4965
         with:
           report-name: 'image-scan'
           report-filename: 'image-scan.report'
@@ -157,7 +157,7 @@ jobs:
             BPF_TARGET=${{ matrix.platform }}
 
       - name: Scan Image
-        uses: timescale/cloud-actions/scan-report@61d7c6131a7f4659ecab0527e4188bdee25d9cbc
+        uses: timescale/cloud-actions/scan-report@74b7a34f9fb318e8a2faabb2169d0f0ba5ec4965
         with:
           report-name: 'image-scan-${{ inputs.docker_target }}-${{ matrix.platform }}'
           report-filename: 'image-scan-${{ inputs.docker_target }}-${{ matrix.platform }}.report'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,6 +69,18 @@ jobs:
           target: ${{ inputs.docker_target }}
           file: ${{ inputs.dockerfile_path }}
 
+      - name: Scan Image
+        uses: timescale/cloud-actions/scan-report@9df8d162ba97e4a1f1556f736dd0163e98f7204d
+        with:
+          report-name: 'image-scan'
+          report-filename: 'image-scan.report'
+          identifier: ${{ inputs.registry }}
+          registry: ${{ inputs.registry }}
+          tags: |
+            ${{ inputs.tags }}
+          severity: 'CRITICAL,HIGH'
+          fail-on-vulns: false
+
   mp-build:
     name: Build multiplatform Image (${{ matrix.platform }})
     if: ${{ inputs.multiplatform }}
@@ -127,6 +139,17 @@ jobs:
             GOOS=linux
             GOARCH=${{ matrix.platform }}
             BPF_TARGET=${{ matrix.platform }}
+
+      - name: Scan Image
+        uses: timescale/cloud-actions/scan-report@9df8d162ba97e4a1f1556f736dd0163e98f7204d
+        with:
+          report-name: 'image-scan-${{ inputs.target }}-${{ matrix.platform }}'
+          report-filename: 'image-scan-${{ inputs.target }}-${{ matrix.platform }}.report'
+          identifier: '${{ inputs.registry }}-${{ inputs.target }}-${{ matrix.platform }}'
+          registry: ${{ inputs.registry }}
+          digest: "${{ steps.build.outputs.digest }}"
+          severity: 'CRITICAL,HIGH'
+          fail-on-vulns: false
 
       - name: Export digest
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
           file: ${{ inputs.dockerfile_path }}
 
       - name: Scan Image
-        uses: timescale/cloud-actions/scan-report@main
+        uses: timescale/cloud-actions/scan-report@3dcd878456384510ab091a51d70cc1a500d76b1d
         with:
           report-name: 'image-scan'
           report-filename: 'image-scan.report'
@@ -157,7 +157,7 @@ jobs:
             BPF_TARGET=${{ matrix.platform }}
 
       - name: Scan Image
-        uses: timescale/cloud-actions/scan-report@main
+        uses: timescale/cloud-actions/scan-report@3dcd878456384510ab091a51d70cc1a500d76b1d
         with:
           report-name: 'image-scan-${{ inputs.docker_target }}-${{ matrix.platform }}'
           report-filename: 'image-scan-${{ inputs.docker_target }}-${{ matrix.platform }}.report'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
           file: ${{ inputs.dockerfile_path }}
 
       - name: Scan Image
-        uses: timescale/cloud-actions/scan-report@74b7a34f9fb318e8a2faabb2169d0f0ba5ec4965
+        uses: timescale/cloud-actions/scan-report@2fb1e775430c448a5a63fd03c2731341e26d85c1
         with:
           report-name: 'image-scan'
           report-filename: 'image-scan.report'
@@ -157,7 +157,7 @@ jobs:
             BPF_TARGET=${{ matrix.platform }}
 
       - name: Scan Image
-        uses: timescale/cloud-actions/scan-report@74b7a34f9fb318e8a2faabb2169d0f0ba5ec4965
+        uses: timescale/cloud-actions/scan-report@2fb1e775430c448a5a63fd03c2731341e26d85c1
         with:
           report-name: 'image-scan-${{ inputs.docker_target }}-${{ matrix.platform }}'
           report-filename: 'image-scan-${{ inputs.docker_target }}-${{ matrix.platform }}.report'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,21 @@ on:
         type: boolean
         default: false
         description: "Multiplatform build"
+      severity:
+        description: 'Severity level (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)'
+        type: string
+        required: false
+        default: 'CRITICAL,HIGH'
+      fail-on-vulns:
+        description: 'Fail build on found vulnerabilities'
+        type: boolean
+        required: false
+        default: 'true'
+      ignore-unfixed:
+        description: 'Ignore unfixed vulnerabilities'
+        type: boolean
+        required: false
+        default: 'true'
     secrets:
       API_TOKEN_GITHUB:
         required: true
@@ -78,8 +93,9 @@ jobs:
           registry: ${{ inputs.registry }}
           tags: |
             ${{ inputs.tags }}
-          severity: 'CRITICAL,HIGH'
-          fail-on-vulns: false
+          severity: ${{ inputs.severity }}
+          ignore-unfixed: ${{ inputs.ignore-unfixed }}
+          fail-on-vulns: ${{ inputs.fail-on-vulns }}
 
   mp-build:
     name: Build multiplatform Image (${{ matrix.platform }})
@@ -148,8 +164,9 @@ jobs:
           identifier: '${{ inputs.registry }}-${{ inputs.target }}-${{ matrix.platform }}'
           registry: ${{ inputs.registry }}
           digest: "${{ steps.build.outputs.digest }}"
-          severity: 'CRITICAL,HIGH'
-          fail-on-vulns: false
+          severity: ${{ inputs.severity }}
+          ignore-unfixed: ${{ inputs.ignore-unfixed }}
+          fail-on-vulns: ${{ inputs.fail-on-vulns }}
 
       - name: Export digest
         run: |


### PR DESCRIPTION
- adding security scan step to `.github/workflows/build.yaml`

Current PR is based on PR #54 and should be merged after it.

For reference:
`timescale/cloud-actions/scan-report` action tested as part of `timescale/cloud-actions/.github/workflows/build.yaml` in `savannah-common` by building go-base and go-builder images.

- action run https://github.com/timescale/savannah-common/actions/runs/13575968631
- issues created:
  - https://github.com/timescale/savannah-common/issues/2138
  - https://github.com/timescale/savannah-common/issues/2139
  - https://github.com/timescale/savannah-common/issues/2140
  - https://github.com/timescale/savannah-common/issues/2141