### PR TITLE
Include a new gh_token secret in builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,6 +88,7 @@ jobs:
           registry: ${{ inputs.registry }}
           target: ${{ inputs.docker_target }}
           file: ${{ inputs.dockerfile_path }}
+          gh-token: ${{ secrets.API_TOKEN_GITHUB }}
 
       - name: Scan Image
         uses: timescale/cloud-actions/scan-report@main
@@ -156,6 +157,8 @@ jobs:
           target: ${{ inputs.docker_target }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ inputs.registry }},push-by-digest=true,name-canonical=true,push=true
+          secrets: |
+            gh_token=${{ secrets.API_TOKEN_GITHUB }}
           build-args: |
             GOOS=linux
             GOARCH=${{ matrix.platform }}

--- a/build-push/action.yaml
+++ b/build-push/action.yaml
@@ -25,6 +25,9 @@ inputs:
   tags:
     description: 'List of tags'
     required: true
+  gh-token:
+    description: 'github token'
+    required: false
 
 runs:
   using: "composite"
@@ -44,6 +47,7 @@ runs:
         tags: ${{ inputs.tags }}
         registry: ${{ inputs.registry }}
         dockerfile: ${{ inputs.file }}
+        gh_token: ${{ inputs.gh-token }}
       run: |
         chmod +x ${{ github.action_path }}/build-push.sh
         ${{ github.action_path }}/build-push.sh

--- a/build-push/build-push.sh
+++ b/build-push/build-push.sh
@@ -6,7 +6,11 @@ for tag in ${tags}; do
 
     # If there is a target we use it
     echo "Building ${registry}:${tag}"
-    [[ ${target} = '' ]] && docker build -t ${registry}:${tag} -f ${dockerfile} . || docker build -t ${registry}:${tag} --target ${target} -f ${dockerfile} .
+    if [[ ${target} = '' ]]; then
+        docker build --secret id=gh_token,env=gh_token -t ${registry}:${tag} -f ${dockerfile} .
+    else
+        docker build --secret id=gh_token,env=gh_token -t ${registry}:${tag} --target ${target} -f ${dockerfile} .
+    fi
     echo "Pushing ${registry}:${tag}"
     docker push ${registry}:${tag}
 done


### PR DESCRIPTION
This should allow the following for `go get` in a Dockerfile:

RUN --mount=type=secret,id=gh_token \
	git config --global "url.https://github-actions:$(cat /run/secrets/gh_token)@github.com/.insteadOf" https://github.com/

** NOTE WELL **

You MUST use multi-stage builds where stages containing this git config aren't included in the image that's pushed to any registries, otherwise the token will be embedded in the image! Build in one stage, copy the build executable from that stage to a release stage, and then push the release stage to the registry.

(The github token that's presented to the builds does expire after 24h, so it's not the end of the world, but it's still important)


This example allows using ssh-agent forwarding when building in a local docker, but uses gh_token in CI:
```
RUN --mount=type=ssh --mount=type=secret,id=gh_token \
    if [[ -f /run/secrets/gh_token && ( -z "${SSH_AUTH_SOCK:-}" || ! -S "${SSH_AUTH_SOCK:-}" ) ]]; then \
        rm -f ~/.gitconfig; \
        git config --global "url.https://github-actions:$(cat /run/secrets/gh_token 2>/dev/null)@github.com/.insteadOf" https://github.com/; \
        go env -u GOPRIVATE; \
    fi; \
    mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
```