### PR TITLE
remove arm64 from multi-platform images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,12 +110,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["amd64", "arm64"]
+        platform: ["amd64"]
         include:
           - platform: amd64
             runs_on: dev-us-east-1
-          - platform: arm64
-            runs_on: arm64
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
GitHub workflow is not finding a runner for arm64 platform. This is causing the savannah-elephant branch deployment to get stuck. Removing the arm64 build option till the arm64 runner situation is sorted.