### PR TITLE
add action for generating debian packages using nfpm

### DIFF
--- a/deb-package/README.md
+++ b/deb-package/README.md
@@ -1,0 +1,33 @@
+## Description
+Installs and generate a deb package with [nfpm](https://nfpm.goreleaser.com/). when the `nfpm-config` input is set.
+
+### How to use it
+> [!NOTE]
+> When using string interpolation use with the `${{ }}` (eg `${{ env.FOO }}`) so they will be processed before calling the action.
+
+```yaml
+    - name: build the deb package
+      uses: timescale/cloud-actions/deb-package@main
+      with:
+        arch: "amd64"               # REQUIRED
+        workdir: ...                # OPTIONAL
+        upload-artifact-name: ...   # OPTIONAL
+        nfpm-version: "2.42.0"      # OPTIONAL
+        nfpm-config: |              # OPTIONAL
+            depends:
+                - postgresql-17
+            contents:
+                - src: target/release/timescaledb_lake-pg17/usr/lib/postgresql/17/lib/timescaledb_lake*
+                dst: /usr/lib/postgresql/17/lib/
+                - src: target/release/timescaledb_lake-pg17/usr/share/postgresql/17/extension/timescaledb_lake*
+                dst: /usr/share/postgresql/17/extension/
+            umask: 2
+            name: timescaledb-pg17
+            arch: amd64
+            platform: linux
+            version: 0.0.1-apr24
+            maintainer: Timescale Engineering <root@timescale.com>
+            description: timescaledb-lake is a PostgreSQL extension
+            homepage: https://github.com/timescale/timescaledb-lake.git
+```
+

--- a/deb-package/action.yaml
+++ b/deb-package/action.yaml
@@ -1,0 +1,94 @@
+---
+name: generate debian package
+description: Generates a debian package using nfpm
+
+inputs:
+  arch:
+    default: "amd64"
+    description: target architecture (e.g., amd64, arm64)
+    required: true
+  workdir:
+    description: working directory
+    required: false
+    default: "."
+  upload-artifact-name:
+    description: name of the artifact to upload
+    required: false
+  nfpm-config:
+    description: nfpm config file contents
+    required: false
+  nfpm-version:
+    description: nfpm version
+    required: false
+    default: "2.42.0"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install nfpm
+      shell: bash
+      env:
+        PLATFORM: ${{ inputs.arch }}
+        NFPM_VERSION: ${{ inputs.nfpm-version }}
+      run: |
+        set -xeu
+        curl -sLO https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_${PLATFORM}.deb
+        dpkg -i nfpm_${NFPM_VERSION}_${PLATFORM}.deb
+
+    - name: Generate debian package
+      if: ${{ inputs.nfpm-config != '' }}
+      shell: bash
+      env:
+        NFPM_CONFIG: ${{ inputs.nfpm-config }}
+        ARCH: ${{ inputs.arch }}
+      id: nfpm
+      working-directory: ${{ inputs.workdir }}
+      run: |-
+        set -xeu
+        echo "${NFPM_CONFIG}" > nfpm.yaml
+        nfpm pkg --packager deb --target ./
+        PACKAGE_NAME=$(ls timescaledb*deb)
+
+        if [ -z "${PACKAGE_NAME}" ]; then
+          echo "Could not find package name"
+          exit 2
+        fi
+
+        echo "package=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
+
+    - name: generate summary
+      if: ${{ inputs.nfpm-config != '' }}
+      shell: bash
+      working-directory: ${{ inputs.workdir }}
+      env:
+        NFPM_CONFIG: ${{ inputs.nfpm-config }}
+        ARCH: ${{ inputs.arch }}
+      run: |-
+        set -xeu
+        PACKAGE_NAME=$(ls timescaledb*deb)
+
+        cat <<EOF > $GITHUB_STEP_SUMMARY
+        ## Package for ${ARCH}
+
+        Generated package: \`${PACKAGE_NAME}\`
+        Package contents:
+        \`\`\`
+        $(dpkg -c ${PACKAGE_NAME})
+        \`\`\`
+
+        NFpm config:
+        \`\`\`yaml
+        $(cat nfpm.yaml)
+        \`\`\`
+        EOF
+
+        if [ "${{ inputs.upload-artifact-name }}" != "" ]; then
+          echo Artifact name: \`${{ inputs.upload-artifact-name }}\` >> $GITHUB_STEP_SUMMARY
+        fi
+
+    - name: Upload deb as Artifact for ${{ inputs.arch }}
+      if: ${{ inputs.upload-artifact-name != '' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.upload-artifact-name }}
+        path: "${{ inputs.workdir }}/${{ steps.nfpm.outputs.package }}"


### PR DESCRIPTION
This pull request introduces a GitHub Action for generating Debian packages using `nfpm`. It includes a detailed setup for configuring the action and generating packages, as well as documentation to guide users. Below are the most important changes grouped by theme:

### New GitHub Action for Debian Package Generation

* Added `deb-package/action.yaml` to define a composite GitHub Action that installs `nfpm`, generates a Debian package based on user-provided configuration, and optionally uploads the package as an artifact. Key inputs include `arch`, `workdir`, `nfpm-config`, and `nfpm-version`.

### Documentation for the New Action

* Updated `deb-package/README.md` with a description of the action, usage instructions, and an example YAML configuration. The documentation explains how to use string interpolation and provides a sample `nfpm-config` for generating a Debian package.