### PR TITLE
Re-enable arm64 builds in GitHub workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,10 +110,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["amd64"]
+        platform: ["amd64", "arm64"]
         include:
           - platform: amd64
             runs_on: dev-us-east-1
+          - platform: arm64
+            runs_on: arm64
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Arm64 builds were previously disabled due to un-availability of arm runners. That problem is fixed now. Re-enabling building arm64 images for GitHub workflows.