### PR TITLE
feat: allow specifying custom repository to checkout

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,10 @@ on:
         type: boolean
         required: false
         default: false
+      repository:
+        description: 'Repository to checkout'
+        type: string
+        required: false
     secrets:
       API_TOKEN_GITHUB:
         required: true
@@ -74,6 +78,7 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ inputs.repository || github.repository }}
           submodules: true
           token: ${{ secrets.API_TOKEN_GITHUB }}
 
@@ -120,6 +125,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          repository: ${{ inputs.repository || github.repository }}
           submodules: true
           token: ${{ secrets.API_TOKEN_GITHUB }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,6 +59,10 @@ on:
         description: 'Repository to checkout'
         type: string
         required: false
+      ref:
+        description: 'Git ref to checkout'
+        type: string
+        required: false
     secrets:
       API_TOKEN_GITHUB:
         required: true
@@ -79,6 +83,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           submodules: true
           token: ${{ secrets.API_TOKEN_GITHUB }}
 
@@ -107,7 +112,7 @@ jobs:
             ${{ inputs.tags }}
           severity: ${{ inputs.severity }}
           ignore-unfixed: '${{ inputs.ignore-unfixed }}'
-          fail-on-vulns: '${{ inputs.fail-on-vulns }}'        
+          fail-on-vulns: '${{ inputs.fail-on-vulns }}'
   mp-build:
     name: Build multiplatform Image (${{ matrix.platform }})
     if: ${{ inputs.multiplatform }}
@@ -125,6 +130,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
           submodules: true
           token: ${{ secrets.API_TOKEN_GITHUB }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,6 +47,10 @@ on:
         type: string
         default: '5m'
         description: 'Extra arguments to specify timeout for help upgrades'
+      repository:
+        description: 'Repository to checkout'
+        type: string
+        required: false
 
     secrets:
       API_TOKEN_GITHUB:
@@ -129,6 +133,7 @@ jobs:
     - name: Setup | Checkout submodules
       uses: actions/checkout@v4
       with:
+        repository: ${{ inputs.repository || github.repository }}
         submodules: true
         token: ${{ secrets.API_TOKEN_GITHUB }}
 
@@ -191,6 +196,7 @@ jobs:
     - name: Setup | Checkout submodules
       uses: actions/checkout@v4
       with:
+        repository: ${{ inputs.repository || github.repository }}
         submodules: true
         token: ${{ secrets.API_TOKEN_GITHUB }}
 
@@ -250,6 +256,7 @@ jobs:
     - name: Setup | Checkout submodules
       uses: actions/checkout@v4
       with:
+        repository: ${{ inputs.repository || github.repository }}
         submodules: true
         token: ${{ secrets.API_TOKEN_GITHUB }}
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -55,6 +55,7 @@ on:
         description: 'Git ref to checkout'
         type: string
         required: false
+
     secrets:
       API_TOKEN_GITHUB:
         required: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -51,7 +51,10 @@ on:
         description: 'Repository to checkout'
         type: string
         required: false
-
+      ref:
+        description: 'Git ref to checkout'
+        type: string
+        required: false
     secrets:
       API_TOKEN_GITHUB:
         required: true
@@ -121,7 +124,7 @@ on:
         description: 'Kubeconfig secret'
       ORG_KUBECONFIG_PROD_AZ_EASTUS:
         required: false
-        description: 'Kubeconfig secret'        
+        description: 'Kubeconfig secret'
 jobs:
   # Deploy by one region
   deploy_on_region:
@@ -133,6 +136,7 @@ jobs:
     - name: Setup | Checkout submodules
       uses: actions/checkout@v4
       with:
+        ref: ${{ inputs.ref || github.ref }}
         repository: ${{ inputs.repository || github.repository }}
         submodules: true
         token: ${{ secrets.API_TOKEN_GITHUB }}
@@ -145,7 +149,7 @@ jobs:
         ORG_KUBECONFIG_DEV_AZ_EASTUS: ${{ secrets.ORG_KUBECONFIG_DEV_AZ_EASTUS }}
         ORG_KUBECONFIG_PROD: ${{ secrets.ORG_KUBECONFIG_PROD }}
         ORG_KUBECONFIG_PROD_EU_WEST_1: ${{ secrets.ORG_KUBECONFIG_PROD_EU_WEST_1 }}
-        ORG_KUBECONFIG_PROD_US_WEST_2: ${{ secrets.ORG_KUBECONFIG_PROD_US_WEST_2 }}        
+        ORG_KUBECONFIG_PROD_US_WEST_2: ${{ secrets.ORG_KUBECONFIG_PROD_US_WEST_2 }}
         ORG_KUBECONFIG_PROD_EU_CENTRAL_1: ${{ secrets.ORG_KUBECONFIG_PROD_EU_CENTRAL_1 }}
         ORG_KUBECONFIG_PROD_AP_SOUTHEAST_2: ${{ secrets.ORG_KUBECONFIG_PROD_AP_SOUTHEAST_2 }}
         ORG_KUBECONFIG_PROD_US_EAST_2: ${{ secrets.ORG_KUBECONFIG_PROD_US_EAST_2 }}
@@ -196,6 +200,7 @@ jobs:
     - name: Setup | Checkout submodules
       uses: actions/checkout@v4
       with:
+        ref: ${{ inputs.ref || github.ref }}
         repository: ${{ inputs.repository || github.repository }}
         submodules: true
         token: ${{ secrets.API_TOKEN_GITHUB }}
@@ -256,6 +261,7 @@ jobs:
     - name: Setup | Checkout submodules
       uses: actions/checkout@v4
       with:
+        ref: ${{ inputs.ref || github.ref }}
         repository: ${{ inputs.repository || github.repository }}
         submodules: true
         token: ${{ secrets.API_TOKEN_GITHUB }}


### PR DESCRIPTION
PR allows specifying a repository when calling the `build` and `deploy` workflows in the case that we want to use the non default repo to build from.

The purpose for us is that we have our code repos (e.g. https://github.com/timescale/tiger-docs-mcp-server) and then the helm charts will live in a different repo, and we want to have that different repo handle calling `cloud-actions/build` and `cloud-actions/deploy`, but obviously need to checkout the code repo.

See https://github.com/timescale/tiger-docs-mcp-server/pull/13 and https://github.com/timescale/tiger-agents-deploy/blob/main/.github/workflows/build-on-feature-branch.yaml for a proof of concept of getting the build workflow to work for us.