### PR TITLE
feat: add docker_context input for build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,7 +93,7 @@ jobs:
           token: ${{ secrets.API_TOKEN_GITHUB }}
 
       - name: Docker | Build and Push
-        uses: timescale/cloud-actions/build-push@mpeveler/feat-docker-context
+        uses: timescale/cloud-actions/build-push@main
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -105,7 +105,6 @@ jobs:
           target: ${{ inputs.docker_target }}
           file: ${{ inputs.dockerfile_path }}
           gh-token: ${{ secrets.API_TOKEN_GITHUB }}
-
 
       - name: Scan Image
         uses: timescale/cloud-actions/scan-report@main

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,11 @@ on:
         type: string
         default: ""
         description: "Dockerfile target"
+      docker_context:
+        required: false
+        type: string
+        default: "."
+        description: "Docker build context"
       runner:
         required: false
         type: string
@@ -88,7 +93,7 @@ jobs:
           token: ${{ secrets.API_TOKEN_GITHUB }}
 
       - name: Docker | Build and Push
-        uses: timescale/cloud-actions/build-push@main
+        uses: timescale/cloud-actions/build-push@mpeveler/feat-docker-context
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -96,9 +101,11 @@ jobs:
           tags: |
             ${{ inputs.tags }}
           registry: ${{ inputs.registry }}
+          context: ${{ inputs.docker_context }}
           target: ${{ inputs.docker_target }}
           file: ${{ inputs.dockerfile_path }}
           gh-token: ${{ secrets.API_TOKEN_GITHUB }}
+
 
       - name: Scan Image
         uses: timescale/cloud-actions/scan-report@main
@@ -163,7 +170,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: ${{ inputs.docker_context}}
           file: ${{ inputs.dockerfile_path }}
           platforms: linux/${{ matrix.platform }}
           target: ${{ inputs.docker_target }}

--- a/build-push/action.yaml
+++ b/build-push/action.yaml
@@ -14,6 +14,10 @@ inputs:
   registry:
     description: 'ECR image repository'
     required: true
+  context:
+    description: 'Docker build context'
+    required: false
+    default: '.'
   file:
     description: 'Dockerfile path (e.g. build/Dockerfile)'
     required: false
@@ -43,6 +47,7 @@ runs:
 
     - name: Docker Build
       env:
+        context: ${{ inputs.context }}
         target: ${{ inputs.target }}
         tags: ${{ inputs.tags }}
         registry: ${{ inputs.registry }}

--- a/build-push/build-push.sh
+++ b/build-push/build-push.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
+cd "${context}" || exit 1
+
 for tag in ${tags}; do
     # Search-and-replace all / characters to -, which allows using github.ref_name in the tag since most branches include a / character.
     tag="${tag//\//-}"
 
     # If there is a target we use it
     echo "Building ${registry}:${tag}"
-    cd "${context}" || exit 1
     if [[ ${target} = '' ]]; then
         docker build --secret id=gh_token,env=gh_token -t ${registry}:${tag} -f ${dockerfile} .
     else

--- a/build-push/build-push.sh
+++ b/build-push/build-push.sh
@@ -6,6 +6,7 @@ for tag in ${tags}; do
 
     # If there is a target we use it
     echo "Building ${registry}:${tag}"
+    cd "${context}" || exit 1
     if [[ ${target} = '' ]]; then
         docker build --secret id=gh_token,env=gh_token -t ${registry}:${tag} -f ${dockerfile} .
     else


### PR DESCRIPTION
PR adds support for passing a `docker_context` input which would be used for the docker build commands. Docker is a bit odd in terms of how context is treated across the different tools with regards to the dockerfile argument, where `docker build` will treat the dockerfile relative to `$(cwd)` while `docker-compose`/`docker/build-push-action` GHA will treat it relative to the passed context. To keep things consistent through the GHA, I setup `build-push.sh` to act "similar" to `docker/build-push-action` by changing directories before running `docker build` so that we're still finding the dockerfile relative to the passed context.